### PR TITLE
Fix/drf spectacular schema errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.trunk/
 
 # Spyder project settings
 .spyderproject

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -115,7 +115,7 @@ class CustomUserViewSet(UserViewSet):
             OpenApiExample(
                 "Bad request",
                 value={
-                    "detail": "Неверный пароль",
+                    "password": "Неверный пароль",
                 },
                 status_codes=["400"],
                 response_only=True,

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,10 +1,16 @@
 from django.contrib.auth import get_user_model, update_session_auth_hash
 from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import (
+    extend_schema,
+    OpenApiExample,
+    inline_serializer
+)
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.serializers import CharField
 
 from djoser.conf import settings
 from djoser.views import UserViewSet
@@ -30,6 +36,29 @@ class TrainingPlanViewSet(viewsets.ModelViewSet):
     http_method_names = ['get', 'post', 'put', 'delete']
 
 
+@extend_schema(
+    responses={
+        200: DietPlanSerializer,
+        400: inline_serializer(
+            name="Error_400",
+            fields={
+                "detail": CharField(),
+            },
+        ),
+    },
+    examples=[
+        OpenApiExample(
+            "Bad request",
+            value={
+                "kkal": ["Убедитесь, что это значение меньше либо равно 10000."],
+                "protein": ["Введите правильное число."],
+                "fat": ["Введите правильное число."]
+            },
+            status_codes=["400"],
+            response_only=True,
+        ),
+    ]
+)
 class DietPlanViewSet(viewsets.ModelViewSet):
     serializer_class = DietPlanSerializer
     queryset = DietPlan.objects.all()
@@ -72,6 +101,27 @@ class CustomUserViewSet(UserViewSet):
         return Response(f'Пользователь {request.data["email"]}удалён.',
                         status=status.HTTP_200_OK)
 
+    @extend_schema(
+        responses={
+            200: CustomUserSerializer,
+            400: inline_serializer(
+                name="Error_400",
+                fields={
+                    "detail": CharField(),
+                },
+            ),
+        },
+        examples=[
+            OpenApiExample(
+                "Bad request",
+                value={
+                    "detail": "Неверный пароль",
+                },
+                status_codes=["400"],
+                response_only=True,
+            ),
+        ]
+    )
     @action(["post"], detail=False, permission_classes=(AllowAny,))
     def user_restore(self, request, *args, **kwargs):
         user = get_object_or_404(User, email=request.data["email"])

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,10 +1,5 @@
 from django.contrib.auth import get_user_model, update_session_auth_hash
 from django.shortcuts import get_object_or_404
-from drf_spectacular.utils import (
-    extend_schema,
-    OpenApiExample,
-    inline_serializer
-)
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
@@ -14,6 +9,8 @@ from rest_framework.serializers import CharField
 
 from djoser.conf import settings
 from djoser.views import UserViewSet
+from drf_spectacular.utils import (OpenApiExample, extend_schema,
+                                   inline_serializer,)
 from users.models import SpecialistClient
 from workouts.models import TrainingPlan
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -50,7 +50,9 @@ class TrainingPlanViewSet(viewsets.ModelViewSet):
         OpenApiExample(
             "Bad request",
             value={
-                "kkal": ["Убедитесь, что это значение меньше либо равно 10000."],
+                "kkal": [
+                    "Убедитесь, что это значение меньше либо равно 10000."
+                ],
                 "protein": ["Введите правильное число."],
                 "fat": ["Введите правильное число."]
             },


### PR DESCRIPTION
Вносимые изменения:
 - добавил .trunk в gitignore (конфиг для линтера, которым пользуюсь);
 - добавил необходимые импорты и прописал extend_schema декораторы для двух вьюсетов, в которых предусмотрены возвращаемые ошибки.
 
Декоратор можно добавлять, как к целому вьюсету, так и отдельному action. Т.к. в первом вьюсете у нас всего одно кастомное действие, добавил декоратор к всему вьюсету, во втором вьюсете несколько добавленных действий, при добавлении декоратора на уровне всего вьюсета drf-spectacular выбрасывает ошибку, насчет того, что сгенерированная схема может быть некорректной, поэтому добавил декоратор на уровне отдельного действия.